### PR TITLE
chore: add data attributes for hook and page type in Layout

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -8,7 +8,7 @@
     {{ head_content }}
     <style>.preloader * { opacity: 0; }.transition-preloader * { transition: none !important }</style>
   </head>
-  <body id="{{ page.permalink }}" class="{{ page.category }} preloader transition-preloader">
+  <body id="{{ page.permalink }}" class="{{ page.category }} preloader transition-preloader" data-bc-page-type="{% if page.category == 'custom' %}custom{% else %}{{ page.permalink }}{% endif %}">
     <a class="skip-link" href="#main">Skip to main content</a>
     {% if theme.announcement_message_text != blank %}
       <div aria-label="Announcement message" class="announcement-message">
@@ -20,7 +20,7 @@
         </button>
       </div>
     {% endif %}
-    <header class="header">
+    <header class="header" data-bc-hook="header">
       <div class="mobile-header">
         <div class="wrapper">
           <button class="open-mobile-navigation" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobile-navigation">
@@ -249,7 +249,7 @@
         </aside>
       {% endif %}
     </main>
-    <footer class="footer">
+    <footer class="footer" data-bc-hook="footer">
       <div class="wrapper">
         <div class="footer-store-name">{{ store.name }}</div>
     		<nav class="footer-nav-links" aria-label="Secondary">

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Sunscreen",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "images": [
     {
       "variable": "logo",


### PR DESCRIPTION
Allows for 3rd party apps to target key regions for adding content. In particular, key for omnisend and email partners to be able to insert content above the footer.

1. Adds `data-bc-hook` attribute to header and footer
2. Adds `data-bc-page-type` attribute to the body tag

Note: A much larger change was previously proposed but I've scaled it back to only the above 2 changes foregoing the larger change which is much more complex.
