### PR TITLE
bug fix for website link in footer

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -324,6 +324,9 @@
         {% if pages.required_pages.size > 0 %}
           {% assign show_pages_section_in_footer = true %}
         {% endif %}
+        {% if store.website != blank %}
+          {% assign show_pages_section_in_footer = true %}
+        {% endif %}
 
     		<nav class="footer-nav-links footer-nav-links--main" aria-label="Footer main">
           <ul>


### PR DESCRIPTION
currently there's a bug specific to the Sunscreen theme where the "back to site" link (aka "website link") won't appear in the footer if there aren't any custom pages or policy pages set, since the website link conditional is contained within a parent conditional that checks if `show_pages_section_in_footer` is true. this fix adds `show_pages_section_in_footer = true` when a website link is present in the Shop Settings section of the admin.

**Current behavior when at least one custom page is present:**
<img width="434" height="255" alt="CleanShotGoogle Chrome 2025-December-02 at 10 15@2x" src="https://github.com/user-attachments/assets/389113a4-0014-4e59-9a02-3962fb0193a4" />

**Current behavior when website link is present but no custom pages:**
<img width="462" height="199" alt="CleanShotGoogle Chrome 2025-December-02 at 10 16@2x" src="https://github.com/user-attachments/assets/64583d39-5f5e-4f73-bbf2-615311aa66a7" />

**Behavior once this fix is implemented:**
<img width="468" height="315" alt="CleanShotGoogle Chrome 2025-December-02 at 10 24@2x" src="https://github.com/user-attachments/assets/1d7a64d3-71df-4844-9736-694ecd503f22" />


