### PR TITLE
Sunscreen v1.21.0

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -47,9 +47,20 @@
                   </a>
                   <div class="option-name">
                     {% unless item.product.has_default_option %}
-                      {{ item.option.name }} - <span class="cart-item-unit-price">{{ item.unit_price | money: theme.money_format }}</span>
+                      {{ item.option.name }} -
+                      {% if theme.show_strikethrough_pricing and item.original_unit_price > item.unit_price %}
+                        <s class="price-compare">{{ item.original_unit_price | money: theme.money_format }}</s>
+                        <span class="cart-item-unit-price price-sale">{{ item.unit_price | money: theme.money_format }}</span>
+                      {% else %}
+                        <span class="cart-item-unit-price">{{ item.unit_price | money: theme.money_format }}</span>
+                      {% endif %}
                     {% else %}
-                      <div class="cart-item-unit-price">{{ item.unit_price | money: theme.money_format }}</div>
+                      {% if theme.show_strikethrough_pricing and item.original_unit_price > item.unit_price %}
+                        <s class="price-compare">{{ item.original_unit_price | money: theme.money_format }}</s>
+                        <div class="cart-item-unit-price price-sale">{{ item.unit_price | money: theme.money_format }}</div>
+                      {% else %}
+                        <div class="cart-item-unit-price">{{ item.unit_price | money: theme.money_format }}</div>
+                      {% endif %}
                     {% endunless %}
                   </div>
                 </div>

--- a/source/home.html
+++ b/source/home.html
@@ -241,7 +241,7 @@
                       {% unless hide_price %}
                         {% if product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                           <div class="product-list-thumb-options-description">
-                            {{ product.options.size }} {{ t['products.variants'] }}
+                            {{ product.options.size }} {{ t['products.variants'] | downcase }}
                           </div>
                         {% endif %}
                       {% endunless %}

--- a/source/home.html
+++ b/source/home.html
@@ -221,7 +221,32 @@
                         {% endif %}
 
                         {% unless hide_price %}
-                          {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                          {% assign show_strikethrough = false %}
+                          {% assign strikethrough_regular = nil %}
+                          {% assign strikethrough_sale = nil %}
+
+                          {% if theme.show_strikethrough_pricing %}
+                            {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                              {% assign show_strikethrough = true %}
+                              {% assign strikethrough_regular = product.original_price %}
+                              {% assign strikethrough_sale = product.default_price %}
+                            {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                              {% assign show_strikethrough = true %}
+                              {% assign strikethrough_regular = product.min_original_price %}
+                              {% assign strikethrough_sale = product.min_price %}
+                            {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                              {% assign show_strikethrough = true %}
+                              {% assign strikethrough_regular = product.max_original_price %}
+                              {% assign strikethrough_sale = product.max_price %}
+                            {% endif %}
+                          {% endif %}
+
+                          {% if show_strikethrough %}
+                            <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                            <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                          {% else %}
+                            {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                          {% endif %}
 
                           {% if product.price_suffix != blank %}
                             {% assign variable_price_shown = true %}

--- a/source/javascripts/cart.js
+++ b/source/javascripts/cart.js
@@ -167,10 +167,13 @@ processUpdate = (input, item_id, new_val, cart) => {
   if (new_val > 0) {
     for (itemIndex = 0; itemIndex < cart.items.length; itemIndex++) {
       if (cart.items[itemIndex].id == item_id) {
-        item_price = cart.items[itemIndex].price;
-        formatted_item_price = formatMoney(item_price, true, true);
-        let priceElement = document.querySelector('.cart-item-price__update[data-item-id="'+item_id+'"]');
-        htmlHighlight(priceElement,formatted_item_price);
+        var item = cart.items[itemIndex];
+        var item_price = item.price;
+        var priceElement = document.querySelector('.cart-item-price__update[data-item-id="'+item_id+'"]');
+
+        // Line total only shows sale price (no strikethrough - strikethrough is on unit price only)
+        var formattedPrice = formatMoney(item_price, true, true);
+        htmlHighlight(priceElement, formattedPrice);
       }
     }
   }

--- a/source/javascripts/product-option-groups.js
+++ b/source/javascripts/product-option-groups.js
@@ -306,7 +306,7 @@ function processAvailableDropdownOptions(product, changed_dropdown) {
     if (product_option) {
       if (!product_option.sold_out && product_option.id > 0) {
         $('#option').val(product_option.id);
-        enableAddButton(product_option.price);
+        enableAddButton(product_option.price, product_option.original_price);
         if (num_option_groups > 1) {
           $('.reset-selection-button').fadeIn('fast');
         }

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -30,7 +30,8 @@ if (themeOptions.productImageZoom === true) {
 }
 $('.product-option-select').on('change',function() {
   var option_price = $(this).find("option:selected").attr("data-price");
-  enableAddButton(option_price);
+  var original_price = $(this).find("option:selected").attr("data-original-price");
+  enableAddButton(option_price, original_price);
 });
 
 function updateInventoryMessage(optionId = null) {
@@ -92,17 +93,35 @@ function updateInventoryMessage(optionId = null) {
   }
 }
 
-function enableAddButton(updated_price) {
+function updateProductPrice(updated_price, original_price) {
+  var priceContainer = $('.product-detail__pricing-value');
+  if (!priceContainer.length || !updated_price) return;
+
+  var updatedNum = parseFloat(updated_price) || 0;
+  var originalNum = parseFloat(original_price) || 0;
+
+  var showStrikethrough = originalNum > updatedNum && themeOptions.showStrikethroughPricing;
+
+  var priceHtml;
+  if (showStrikethrough) {
+    var regularFormatted = formatMoney(original_price, true, true);
+    var saleFormatted = formatMoney(updated_price, true, true);
+    priceHtml = '<s class="price-compare">' + regularFormatted + '</s> <span class="price-sale">' + saleFormatted + '</span>';
+  } else {
+    priceHtml = formatMoney(updated_price, true, true);
+  }
+
+  priceContainer.html(priceHtml);
+}
+
+function enableAddButton(updated_price, original_price) {
   var addButton = $('.add-to-cart-button');
   var addButtonTitle = addButton.attr('data-add-title');
   addButton.attr("disabled",false);
   if (updated_price) {
-    priceTitle = ' - ' + formatMoney(updated_price, true, true);
+    updateProductPrice(updated_price, original_price);
   }
-  else {
-    priceTitle = '';
-  }
-  addButton.html(addButtonTitle + priceTitle);
+  addButton.html(addButtonTitle);
   addButton.attr('aria-label',addButton.text());
   updateInventoryMessage($('#option').val());
   showBnplMessaging(updated_price, { alignment: 'left', displayMode: 'grid', pageType: 'product' });

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -129,9 +129,7 @@ function enableAddButton(updated_price, original_price) {
   var addButton = $('.add-to-cart-button');
   var addButtonTitle = addButton.attr('data-add-title');
   addButton.attr("disabled",false);
-  if (updated_price) {
-    updateProductPrice(updated_price, original_price);
-  }
+  updateProductPrice(updated_price, original_price);
   addButton.html(addButtonTitle);
   addButton.attr('aria-label',addButton.text());
   updateInventoryMessage($('#option').val());

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -95,7 +95,18 @@ function updateInventoryMessage(optionId = null) {
 
 function updateProductPrice(updated_price, original_price) {
   var priceContainer = $('.product-detail__pricing-value');
-  if (!priceContainer.length || !updated_price) return;
+  if (!priceContainer.length) return;
+
+  if (!updated_price) {
+    if (priceContainer.data('original-html') !== undefined) {
+      priceContainer.html(priceContainer.data('original-html'));
+    }
+    return;
+  }
+
+  if (priceContainer.data('original-html') === undefined) {
+    priceContainer.data('original-html', priceContainer.html());
+  }
 
   var updatedNum = parseFloat(updated_price) || 0;
   var originalNum = parseFloat(original_price) || 0;

--- a/source/layout.html
+++ b/source/layout.html
@@ -324,6 +324,9 @@
         {% if pages.required_pages.size > 0 %}
           {% assign show_pages_section_in_footer = true %}
         {% endif %}
+        {% if store.website != blank %}
+          {% assign show_pages_section_in_footer = true %}
+        {% endif %}
 
     		<nav class="footer-nav-links footer-nav-links--main" aria-label="Footer main">
           <ul>

--- a/source/layout.html
+++ b/source/layout.html
@@ -274,7 +274,32 @@
                               {% endif %}
 
                               {% unless hide_price %}
-                                {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                                {% assign show_strikethrough = false %}
+                                {% assign strikethrough_regular = nil %}
+                                {% assign strikethrough_sale = nil %}
+
+                                {% if theme.show_strikethrough_pricing %}
+                                  {% if related_product.variable_pricing == false and related_product.original_price > related_product.default_price %}
+                                    {% assign show_strikethrough = true %}
+                                    {% assign strikethrough_regular = related_product.original_price %}
+                                    {% assign strikethrough_sale = related_product.default_price %}
+                                  {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and related_product.min_original_price > related_product.min_price %}
+                                    {% assign show_strikethrough = true %}
+                                    {% assign strikethrough_regular = related_product.min_original_price %}
+                                    {% assign strikethrough_sale = related_product.min_price %}
+                                  {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and related_product.max_original_price > related_product.max_price %}
+                                    {% assign show_strikethrough = true %}
+                                    {% assign strikethrough_regular = related_product.max_original_price %}
+                                    {% assign strikethrough_sale = related_product.max_price %}
+                                  {% endif %}
+                                {% endif %}
+
+                                {% if show_strikethrough %}
+                                  <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                                  <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                                {% else %}
+                                  {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                                {% endif %}
 
                                 {% if related_product.price_suffix != blank %}
                                   {% assign variable_price_shown = true %}
@@ -652,6 +677,7 @@
       };
       const themeOptions = {
         showSoldOutOptions: {{ theme.show_sold_out_product_options }},
+        showStrikethroughPricing: {{ theme.show_strikethrough_pricing }},
         showLowInventoryMessages: {{ theme.show_low_inventory_messages }},
         lowInventoryMessage: "{{ t['products.low_inventory'] | replace: '"', '\"' | replace: "'", "\\'" }}",
         almostSoldOutMessage: "{{ t['products.almost_sold_out'] | replace: '"', '\"' | replace: "'", "\\'" }}",

--- a/source/layout.html
+++ b/source/layout.html
@@ -293,7 +293,7 @@
                             {% unless hide_price %}
                               {% if related_product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                                 <div class="product-list-thumb-options-description">
-                                  {{ related_product.options.size }} {{ t['products.variants'] }}
+                                  {{ related_product.options.size }} {{ t['products.variants'] | downcase }}
                                 </div>
                               {% endif %}
                             {% endunless %}

--- a/source/layout.html
+++ b/source/layout.html
@@ -138,9 +138,6 @@
                         {% for category in categories.active %}
                           <li>{{ category | link_to }}</li>
                         {% endfor %}
-                        {% if pages.subscribe_page %}
-                          <li class="artist-support"><a href="{{ pages.subscribe_page.url }}">{{ t['navigation.subscribe'] }}</a></li>
-                        {% endif %}
                       </ul>
                     {% endif %}
                   </div>
@@ -154,6 +151,10 @@
               {% for custom_page in pages.custom_pages limit: theme.nav_items %}
               <li class="header-page-link">{{ custom_page | link_to }}</li>
               {% endfor %}
+            {% endif %}
+
+            {% if pages.subscribe_page %}
+              <li class="header-page-link"><a href="{{ pages.subscribe_page.url }}">{{ t['navigation.subscribe'] }}</a></li>
             {% endif %}
 
             {% if theme.nav_page_display == 'all' or theme.nav_page_display == 'contact_only' %}

--- a/source/product.html
+++ b/source/product.html
@@ -75,6 +75,7 @@
                 <img
                   alt=""
                   class="lazyload"
+                  loading="lazy"
                   src="{{ image | product_image_url | constrain: 150 }}"
                   data-srcset="
                     {{ image | product_image_url | constrain: 250 }} 250w,

--- a/source/product.html
+++ b/source/product.html
@@ -235,10 +235,10 @@
                     {% if option.original_price > option.price %}
                       {% assign option_is_on_sale = true %}
                     {% endif %}
-                    {% if product.on_sale and option_is_on_sale and theme.show_sale_label_in_product_options %}
-                      {% unless option.sold_out %}
-                        {% assign sale_label = ' (' | append: t['products.on_sale'] | append: ')' %}
-                      {% endunless %}
+                    {% if option.sold_out %}
+                      {% assign sale_label = ' (' | append: t['products.sold_out'] | append: ')' %}
+                    {% elsif product.on_sale and option_is_on_sale and theme.show_sale_label_in_product_options %}
+                      {% assign sale_label = ' (' | append: t['products.on_sale'] | append: ')' %}
                     {% endif %}
                     <option value="{{ option.id }}" data-price="{{ option.price }}" data-original-price="{{ option.original_price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }}{{ sale_label }}</option>
                   {% endfor %}

--- a/source/product.html
+++ b/source/product.html
@@ -117,7 +117,34 @@
   <section class="product-detail">
     <div class="product-detail__header">
       {% capture product_pricing %}
-        {{ product | product_price: theme.money_format }}
+        {% assign show_strikethrough = false %}
+        {% assign strikethrough_regular = nil %}
+        {% assign strikethrough_sale = nil %}
+
+        {% if theme.show_strikethrough_pricing %}
+          {% if product.variable_pricing == false and product.original_price > product.default_price %}
+            {% assign show_strikethrough = true %}
+            {% assign strikethrough_regular = product.original_price %}
+            {% assign strikethrough_sale = product.default_price %}
+          {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+            {% assign show_strikethrough = true %}
+            {% assign strikethrough_regular = product.min_original_price %}
+            {% assign strikethrough_sale = product.min_price %}
+          {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+            {% assign show_strikethrough = true %}
+            {% assign strikethrough_regular = product.max_original_price %}
+            {% assign strikethrough_sale = product.max_price %}
+          {% endif %}
+        {% endif %}
+
+        <span class="product-detail__pricing-value">
+          {% if show_strikethrough %}
+            <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+            <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+          {% else %}
+            {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+          {% endif %}
+        </span>
 
         {% if product.price_suffix != blank %}
           {% assign variable_price_shown = true %}
@@ -173,10 +200,25 @@
                 <input id="option" name="cart[add][id]" type="hidden" value="0">
                 {% for option_group in product.option_groups %}
                   <div class="select">
-                    <select data-unavailable-text="(Unavailable)" data-sold-text="({{ t['products.sold_out'] }})" data-group-id="{{ option_group.id }}" data-group-name="{{ option_group.name | escape }}" class="product_option_group" name="option_group[{{ option_group.id }}]" aria-label="Select {{ option_group.name | escape }}" required>
+                    <select data-unavailable-text="(Unavailable)" data-sold-text="({{ t['products.sold_out'] }})" data-sale-text="({{ t['products.on_sale'] }})" data-group-id="{{ option_group.id }}" data-group-name="{{ option_group.name | escape }}" class="product_option_group" name="option_group[{{ option_group.id }}]" aria-label="Select {{ option_group.name | escape }}" required>
                       <option value="" disabled="disabled" selected>{{ option_group.name }}</option>
                       {% for value in option_group.values %}
-                        <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}</option>
+                        {% assign option_status_label = '' %}
+                        {% if product.option_groups.size == 1 %}
+                          {% for option in product.options %}
+                            {% for ogv in option.option_group_values %}
+                              {% if ogv.id == value.id %}
+                                {% if option.sold_out %}
+                                  {% assign option_status_label = t['products.sold_out'] %}
+                                {% elsif option.original_price > option.price and theme.show_sale_label_in_product_options %}
+                                  {% assign option_status_label = t['products.on_sale'] | downcase %}
+                                {% endif %}
+                                {% break %}
+                              {% endif %}
+                            {% endfor %}
+                          {% endfor %}
+                        {% endif %}
+                        <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}{% if option_status_label != blank %} ({{ option_status_label }}){% endif %}</option>
                       {% endfor %}
                     </select>
                     <svg aria-hidden="true" fill="currentColor" class="down-arrow" width="13" height="15" viewBox="0 0 13 15" xmlns="http://www.w3.org/2000/svg"><path d="M13 8.35885695l-1.05568445-1.0024981-4.69025523 4.39122407V-4e-7H5.74593968v11.74758332L1.0556845 7.35635885 0 8.35885695 6.5 14.444444z" fill-rule="nonzero"/></svg>
@@ -188,7 +230,17 @@
                 <select class="product-option-select" id="option" name="cart[add][id]" aria-label="{{ t['products.select_variant'] }}" required>
                   <option value="" disabled="disabled" selected>{{ t['products.select_variant'] }}</option>
                   {% for option in product.options %}
-                    <option value="{{ option.id }}" data-price="{{ option.price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }} {% if option.sold_out %} ({{ t['products.sold_out'] }}){% endif %}</option>
+                    {% assign sale_label = '' %}
+                    {% assign option_is_on_sale = false %}
+                    {% if option.original_price > option.price %}
+                      {% assign option_is_on_sale = true %}
+                    {% endif %}
+                    {% if product.on_sale and option_is_on_sale and theme.show_sale_label_in_product_options %}
+                      {% unless option.sold_out %}
+                        {% assign sale_label = ' (' | append: t['products.on_sale'] | append: ')' %}
+                      {% endunless %}
+                    {% endif %}
+                    <option value="{{ option.id }}" data-price="{{ option.price }}" data-original-price="{{ option.original_price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }}{{ sale_label }}</option>
                   {% endfor %}
                 </select>
                 <svg aria-hidden="true" fill="currentColor" class="down-arrow" width="13" height="15" viewBox="0 0 13 15" xmlns="http://www.w3.org/2000/svg"><path d="M13 8.35885695l-1.05568445-1.0024981-4.69025523 4.39122407V-4e-7H5.74593968v11.74758332L1.0556845 7.35635885 0 8.35885695 6.5 14.444444z" fill-rule="nonzero"/></svg>

--- a/source/product.html
+++ b/source/product.html
@@ -28,9 +28,19 @@
                 {% endif %}
                   <img
                     alt="Image {{ forloop.index }} of {{ product.name | escape }}"
-                    class="product-image lazyload"
+                    class="product-image{% unless forloop.index == 1 %} lazyload{% endunless %}"
                     {% if forloop.index == 1 %}fetchpriority="high"{% else %}loading="lazy"{% endif %}
                     src="{{ image | product_image_url | constrain: 200 }}"
+                    {% if forloop.index == 1 %}
+                    srcset="
+                      {{ image | product_image_url | constrain: 400 }} 400w,
+                      {{ image | product_image_url | constrain: 700 }} 700w,
+                      {{ image | product_image_url | constrain: 1000 }} 1000w,
+                      {{ image | product_image_url | constrain: 1400 }} 1400w,
+                      {{ image | product_image_url | constrain: 2000 }} 2000w,
+                    "
+                    sizes="(min-width: 768px) 50vw, 100vw"
+                    {% else %}
                     data-srcset="
                       {{ image | product_image_url | constrain: 400 }} 400w,
                       {{ image | product_image_url | constrain: 700 }} 700w,
@@ -38,9 +48,10 @@
                       {{ image | product_image_url | constrain: 1400 }} 1400w,
                       {{ image | product_image_url | constrain: 2000 }} 2000w,
                     "
+                    data-sizes="auto"
+                    {% endif %}
                     width="{{ image.height | times: aspect_ratio }}"
                     height="{{ image.height }}"
-                    data-sizes="auto"
                   >
                 {% if theme.product_image_zoom %}</a>{% else %}</div>{% endif %}
               </div>
@@ -98,17 +109,17 @@
       {% endif %}
         <img
           alt="{{ product.name | escape }}"
-          class="blur-up product-image lazyload"
+          class="blur-up product-image"
           fetchpriority="high"
           src="{{ product.image | product_image_url | constrain: 200 }}"
-          data-srcset="
+          srcset="
             {{ product.image | product_image_url | constrain: 400 }} 400w,
             {{ product.image | product_image_url | constrain: 700 }} 700w,
             {{ product.image | product_image_url | constrain: 1000 }} 1000w,
             {{ product.image | product_image_url | constrain: 1400 }} 1400w,
             {{ product.image | product_image_url | constrain: 2000 }} 2000w,
           "
-          data-sizes="auto"
+          sizes="(min-width: 768px) 50vw, 100vw"
         >
       {% if theme.product_image_zoom %}</a>{% else %}</div>{% endif %}
     {% endif %}

--- a/source/product.html
+++ b/source/product.html
@@ -206,8 +206,6 @@
         {% endif %}
       </form>
     {% endif %}
-    {% if product.description != blank %}
-      <div class="product-detail__description">{{ product.description | paragraphs }}</div>
-    {% endif %}
+    <div class="product-detail__description" data-bc-hook="product-description">{%- if product.description != blank %}{{ product.description | paragraphs }}{% endif -%}</div>
   </section>
 </div>

--- a/source/products.html
+++ b/source/products.html
@@ -85,7 +85,32 @@
                   {% endif %}
 
                   {% unless hide_price %}
-                    {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                    {% assign show_strikethrough = false %}
+                    {% assign strikethrough_regular = nil %}
+                    {% assign strikethrough_sale = nil %}
+
+                    {% if theme.show_strikethrough_pricing %}
+                      {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.original_price %}
+                        {% assign strikethrough_sale = product.default_price %}
+                      {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.min_original_price %}
+                        {% assign strikethrough_sale = product.min_price %}
+                      {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                        {% assign show_strikethrough = true %}
+                        {% assign strikethrough_regular = product.max_original_price %}
+                        {% assign strikethrough_sale = product.max_price %}
+                      {% endif %}
+                    {% endif %}
+
+                    {% if show_strikethrough %}
+                      <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                      <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                    {% else %}
+                      {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                    {% endif %}
 
                     {% if product.price_suffix != blank %}
                       {% assign variable_price_shown = true %}

--- a/source/products.html
+++ b/source/products.html
@@ -105,7 +105,7 @@
                 {% unless hide_price %}
                   {% if product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                     <div class="product-list-thumb-options-description">
-                      {{ product.options.size }} {{ t['products.variants'] }}
+                      {{ product.options.size }} {{ t['products.variants'] | downcase }}
                     </div>
                   {% endif %}
                 {% endunless %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Sunscreen",
-  "version": "1.20.4",
+  "version": "1.21.0",
   "images": [
     {
       "variable": "logo_image",

--- a/source/settings.json
+++ b/source/settings.json
@@ -892,6 +892,25 @@
       "description": "Choose how to display prices in your product grid when a product's variants have different prices. Individual product pages will always show the full range."
     },
     {
+      "variable": "show_strikethrough_pricing",
+      "label": "Show strikethrough pricing",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the original price crossed out next to the sale price",
+      "requires": [
+        "feature:theme_strikethrough_pricing eq visible"
+      ]
+    },
+    {
+      "variable": "show_sale_label_in_product_options",
+      "label": "Show sale label in variant dropdowns",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Adds a sale indicator next to discounted variants in the dropdown"
+    },
+    {
       "variable": "show_product_variant_count_in_grid",
       "label": "Show product variant count in product grids",
       "section": "product_page",

--- a/source/settings.json
+++ b/source/settings.json
@@ -578,7 +578,8 @@
       "options": [
         ["Default (Sentence case)", "initial"],
         ["Uppercase", "uppercase"],
-        ["Lowercase", "lowercase"]
+        ["Lowercase", "lowercase"],
+        ["Titlecase", "capitalize"]
       ],
       "default": "initial",
       "description": "Controls the text case styling in your main navigation"
@@ -591,7 +592,8 @@
       "options": [
         ["Default (Sentence case)", "initial"],
         ["Uppercase", "uppercase"],
-        ["Lowercase", "lowercase"]
+        ["Lowercase", "lowercase"],
+        ["Titlecase", "capitalize"]
       ],
       "default": "initial",
       "description": "Controls the text case styling in the footer, excluding custom footer text"

--- a/source/stylesheets/layout.sass
+++ b/source/stylesheets/layout.sass
@@ -223,6 +223,17 @@ h1
     @media screen and (max-width: $break-medium)
       right: -6px
 
+    .cart-link
+      display: flex
+      align-items: center
+      gap: 6px
+      padding: 6px
+
+      svg
+        flex-shrink: 0
+        width: 24px
+        height: 24px
+
   .wrapper
     display: flex
     align-items: center
@@ -297,6 +308,16 @@ h1
 
   .header-right
     justify-self: flex-end
+
+    .cart-link
+      display: flex
+      align-items: center
+      gap: 6px
+
+      svg
+        flex-shrink: 0
+        width: 23px
+        height: 20px
 
   @media screen and (max-width: $break-medium)
     grid-template-columns: minmax(0, 1fr)

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -82,6 +82,10 @@
     .price-suffix
       margin-left: 5px
 
+    .price-compare
+      opacity: 0.6
+      margin-right: 8px
+
   &__description
     font-size: calc(1rem * var(--product-description-scale, 1))
 

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -198,3 +198,6 @@
 #stripe-messaging-container,
 #paypal-messaging-container
   transition: min-height 0.1s ease-out
+
+.product-detail__description:empty
+  display: none

--- a/source/stylesheets/product.sass
+++ b/source/stylesheets/product.sass
@@ -35,6 +35,11 @@
   @media screen and (max-width: $break-large)
     max-width: 100%
 
+  select span, select span option
+    display: none
+    opacity: 0
+    visibility: hidden
+
 .product-selects
   margin-bottom: 20px
 


### PR DESCRIPTION
## Summary

### Features
- **Strikethrough pricing** — Display original prices with strikethrough when items are on sale
- **Titlecase nav text transformation** — New option to apply titlecase formatting to navigation text

### Fixes
- **Product description container always in DOM** — The product description container is now always rendered (with a `data-bc-hook`) so it can be targeted by JS, and hidden via CSS `:empty` when there's no description
- **Subscribe link in nav** — Subscribe link now correctly displays in the navigation
- **Cart icon size and spacing** — Fixed cart icon sizing and spacing issues
- **"Back to site" footer link** — The "back to site" link now correctly displays in the footer when available
- **Sold out label in simple select dropdown** — Restored the "(Sold out)" text label for sold-out options in the simple variant select dropdown

### Chores
- Lowercase label for options text in product grid
- Version bump to 1.21.0